### PR TITLE
Fix Github org to fix a 404 link

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-zitadel/sdk
+module github.com/pulumiverse/pulumi-zitadel/sdk
 
 go 1.17
 


### PR DESCRIPTION
Because `sdk/go.mod` still has the wrong Github organization in it, the package is [not rendered correctly on pkg.go.dev](https://pkg.go.dev/github.com/pulumiverse/pulumi-zitadel/sdk/go). Because of this, the Pulumi docs generation reports a 404 link.

I expect by fixing the Go module name, that the docs processing will work again.

Please publish a new release after merging this PR.